### PR TITLE
Remove deprecated maintainer instruction from dockerfiles

### DIFF
--- a/html/container/Application/Dockerfile
+++ b/html/container/Application/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx
-MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 COPY . /usr/share/nginx/html

--- a/python/bottle/container/Application/Dockerfile
+++ b/python/bottle/container/Application/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 
 RUN apt-get update && apt-get install -y python-pip python-dev && apt-get clean
 RUN pip install bottle

--- a/python/django/container/Application/Dockerfile
+++ b/python/django/container/Application/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 
 RUN apt-get update && apt-get install -y python-pip python-dev && apt-get clean
 

--- a/python/flask/container/Application/Dockerfile
+++ b/python/flask/container/Application/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
+LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 RUN apt-get update -y
 RUN apt-get install -y python-pip python-dev build-essential
 COPY . /app


### PR DESCRIPTION
The`MAINTAINER` instruction from Dockerfile since is deprecated. 
Replacing the instruction with `LABEL`.

See: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated