### PR TITLE
Remove `-onbuild` suffix from node containers [deprecated]

### DIFF
--- a/node/express/kubernetes/Application/Dockerfile
+++ b/node/express/kubernetes/Application/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:8-onbuild
-MAINTAINER Azure App Services Container Images <appsvc-images@microsoft.com>
+FROM node:8
+LABEL maintainer="Azure App Services Container Images <appsvc-images@microsoft.com>"
+
 ENV PORT 8080
 EXPOSE 8080
 

--- a/node/plain/kubernetes/Application/Dockerfile
+++ b/node/plain/kubernetes/Application/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:8-onbuild
-
-# FROM node:6.9.3
+FROM node:8
 LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 
 # Create app directory

--- a/node/sail.js/kubernetes/Application/Dockerfile
+++ b/node/sail.js/kubernetes/Application/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:8-onbuild
-
-# FROM node:6.9.3
+FROM node:8
 LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 
 # Create app directory


### PR DESCRIPTION
The node:X-onbuild images are deprecated (see https://github.com/docker-library/official-images/issues/2076 for more details) for the samples just rely on the base image.