### PR TITLE
Avoid the reset to 0 every time we update the app, kill a pod, etc.

### DIFF
--- a/node/express/kubernetes/Application/routes/index.js
+++ b/node/express/kubernetes/Application/routes/index.js
@@ -9,7 +9,6 @@ console.log("Trying to create redis client");
 var client = redis.createClient(6379, redisServer);
 
 console.log("Redis Client created");
-client.set('viewCount', 0);
 
 /* GET home page. */
 router.get('/', function (req, res) {


### PR DESCRIPTION
Avoid the reset to 0 every time we update the app, kill a pod, etc.

This line of code is not necessary even when that's the first init.
