### PR TITLE
Enable Application Insights for telemetries

### DIFF
--- a/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/Startup.cs
+++ b/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/Startup.cs
@@ -30,6 +30,9 @@ namespace aspnet_core_dotnet_core
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
+            // Enable Application Insights for telemetries. Update the instrumentation key in 'appsettings.json' to transfer the events.
+            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsKubernetesEnricher();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }

--- a/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApplicationInsights": {
+    "InstrumentationKey": "--- Your Application Insights Instrumentation Key ---"
+  }
 }

--- a/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/aspnet-core-dotnet-core.csproj
+++ b/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/aspnet-core-dotnet-core.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.9.406" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.4.10" />


### PR DESCRIPTION
Enable Application Insights to make this example parity with the .NET Core 1.0 example.