### PR TITLE
Users/hiyada/cred scan resolve

### DIFF
--- a/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
@@ -61,7 +61,7 @@
   <connectionStrings>
     <add
       name="defaultConnection"
-      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password="
+      connectionString="YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
       providerName="System.Data.SqlClient"
   />
   </connectionStrings>

--- a/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
@@ -61,7 +61,7 @@
   <connectionStrings>
     <add
       name="defaultConnection"
-      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=root;Password=paSSw0rd"
+      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=root;Password=alpha"
       providerName="System.Data.SqlClient"
   />
   </connectionStrings>

--- a/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet/mssqldb/Application/SampleWebApplication/Web.config
@@ -61,7 +61,7 @@
   <connectionStrings>
     <add
       name="defaultConnection"
-      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=root;Password=alpha"
+      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password="
       providerName="System.Data.SqlClient"
   />
   </connectionStrings>

--- a/dotnet/aspnet/mssqldbWithTests/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet/mssqldbWithTests/Application/SampleWebApplication/Web.config
@@ -61,7 +61,7 @@
   <connectionStrings>
     <add
       name="defaultConnection"
-      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=root;Password=paSSw0rd"
+      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password="
       providerName="System.Data.SqlClient"
   />
   </connectionStrings>

--- a/dotnet/aspnet/mssqldbWithTests/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet/mssqldbWithTests/Application/SampleWebApplication/Web.config
@@ -61,7 +61,7 @@
   <connectionStrings>
     <add
       name="defaultConnection"
-      connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password="
+      connectionString="YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
       providerName="System.Data.SqlClient"
   />
   </connectionStrings>

--- a/dotnet/aspnet46/vm-mssqldb/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet46/vm-mssqldb/Application/SampleWebApplication/Web.config
@@ -67,6 +67,6 @@
     </compilers>
   </system.codedom>
   <connectionStrings>
-    <add name="defaultConnection" connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=root;Password=paSSw0rd" providerName="System.Data.SqlClient"/>
+    <add name="defaultConnection" connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password=" providerName="System.Data.SqlClient"/>
   </connectionStrings>
 </configuration>

--- a/dotnet/aspnet46/vm-mssqldb/Application/SampleWebApplication/Web.config
+++ b/dotnet/aspnet46/vm-mssqldb/Application/SampleWebApplication/Web.config
@@ -67,6 +67,6 @@
     </compilers>
   </system.codedom>
   <connectionStrings>
-    <add name="defaultConnection" connectionString="Data Source=localhost;Initial Catalog=localhost;User ID=;Password=" providerName="System.Data.SqlClient"/>
+    <add name="defaultConnection" connectionString="YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline" providerName="System.Data.SqlClient"/>
   </connectionStrings>
 </configuration>

--- a/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
     "ConnectionStrings": {
-        "DefaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "DefaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
     }
 }

--- a/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
     "ConnectionStrings": {
-        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=root;Password=paSSw0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+        "defaultConnection": "Server=tcp:localhost;Initial Catalog=database;Persist Security Info=False;User ID=;Password=;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
     }
 }

--- a/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
+    "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
   }
 }

--- a/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=dbadmin@xxxxx.database.windows.net;Password=xxxxx;"
+    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
   }
 }

--- a/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
+    "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
   }
 }

--- a/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore22/mssqldbWithTests/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=dbadmin@xxxxx.database.windows.net;Password=xxxxx;"
+    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
   }
 }

--- a/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
+    "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
   }
 }

--- a/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
+++ b/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.Development.json
@@ -8,6 +8,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=dbadmin@xxxxx.database.windows.net;Password=xxxxx;"
+    "defaultConnection": "Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
   }
 }

--- a/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
+    "defaultConnection": "YourSqlDatabaseConnectionString#WillBeInjectedByDeployPipeline"
   }
 }

--- a/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
+++ b/dotnet/aspnetcore22/vm-mssqldb/Application/aspnet-core-dotnet-core/appsettings.json
@@ -6,6 +6,6 @@
         }
     },
   "ConnectionStrings": {
-    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=dbadmin@xxxxx.database.windows.net;Password=xxxxx;"
+    "defaultConnection": "value injected by pipeline - Data Source=tcp:xxxxx.database.windows.net,1433;Initial Catalog=xxxx;User Id=;Password=;"
   }
 }


### PR DESCRIPTION
Some of the passwords here are flashed by cred scanner.
These passwords are not usable as the user production connection string is overwritten in the task and for local the id and password at the development machine should match the connection string credentials. 
Hence removing all passwords from .Net and .Net core projects.