### PR TITLE
Removing Python extension from Arm templates for sample apps

### DIFF
--- a/python/bottle/webappWithTests/ArmTemplates/windows-webapp-template.json
+++ b/python/bottle/webappWithTests/ArmTemplates/windows-webapp-template.json
@@ -35,16 +35,6 @@
                     ],
                     "properties": {
                     }
-                },
-                {
-                    "type": "siteextensions",
-                    "name": "azureappservice-python353x86",
-                    "apiVersion": "2015-08-01",
-                    "properties": {},
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('webAppName'))]",
-                        "[concat('Microsoft.Web/sites/', parameters('webAppName'), '/siteextensions/', 'Microsoft.ApplicationInsights.AzureWebSites')]"
-                    ]
                 }
             ],
             "properties": {

--- a/python/django/webappWithTests/ArmTemplates/windows-webapp-template.json
+++ b/python/django/webappWithTests/ArmTemplates/windows-webapp-template.json
@@ -35,16 +35,6 @@
                     ],
                     "properties": {
                     }
-                },
-                {
-                    "type": "siteextensions",
-                    "name": "azureappservice-python353x86",
-                    "apiVersion": "2015-08-01",
-                    "properties": {},
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('webAppName'))]",
-                        "[concat('Microsoft.Web/sites/', parameters('webAppName'), '/siteextensions/', 'Microsoft.ApplicationInsights.AzureWebSites')]"
-                    ]
                 }
             ],
             "properties": {

--- a/python/flask/webappWithTests/ArmTemplates/windows-webapp-template.json
+++ b/python/flask/webappWithTests/ArmTemplates/windows-webapp-template.json
@@ -35,16 +35,6 @@
                     ],
                     "properties": {
                     }
-                },
-                {
-                    "type": "siteextensions",
-                    "name": "azureappservice-python353x86",
-                    "apiVersion": "2015-08-01",
-                    "properties": {},
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('webAppName'))]",
-                        "[concat('Microsoft.Web/sites/', parameters('webAppName'), '/siteextensions/', 'Microsoft.ApplicationInsights.AzureWebSites')]"
-                    ]
                 }
             ],
             "properties": {


### PR DESCRIPTION
 Removing Python extension from Arm templates for sample apps as it is already part of RD task.
#[1609163](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1609163/)