### PR TITLE
[Bug 1653561] : Laravel php build failed for pipeline template

### DIFF
--- a/php/laravel/container/Application/Dockerfile
+++ b/php/laravel/container/Application/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7
 RUN apt-get update -y && apt-get install -y openssl zip unzip git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN docker-php-ext-install pdo mbstring
+RUN docker-php-ext-install pdo
 WORKDIR /app
 COPY . /app
 RUN composer install

--- a/php/laravel/containerWithTests/Application/Dockerfile
+++ b/php/laravel/containerWithTests/Application/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7
 RUN apt-get update -y && apt-get install -y openssl zip unzip git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN docker-php-ext-install pdo mbstring
+RUN docker-php-ext-install pdo
 WORKDIR /app
 COPY . /app
 RUN composer install

--- a/php/plain/container/Application/Dockerfile
+++ b/php/plain/container/Application/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7-apache
 LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 RUN apt-get update -y && apt-get install -y openssl zip unzip git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN docker-php-ext-install pdo mbstring
+RUN docker-php-ext-install pdo
 
 COPY . /var/www/html/
 RUN composer install

--- a/php/plain/containerWithTests/Application/Dockerfile
+++ b/php/plain/containerWithTests/Application/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7-apache
 LABEL maintainer="Azure App Service Container Images <appsvc-images@microsoft.com>"
 RUN apt-get update -y && apt-get install -y openssl zip unzip git
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN docker-php-ext-install pdo mbstring
+RUN docker-php-ext-install pdo
 
 COPY . /var/www/html/
 RUN composer install


### PR DESCRIPTION
The pipeline for container application of php (both simple and lavarel) were failing due to the error : No package 'oniguruma' found

Removing "mbstring" from respective docker files to resolve the same.
