### PR TITLE
Upgrading php version to 7.3

### DIFF
--- a/php/plain/webapp/armTemplates/windows-webapp-template.json
+++ b/php/plain/webapp/armTemplates/windows-webapp-template.json
@@ -60,7 +60,7 @@
                             "value": "6.9.1"
                         }
                     ],
-                    "phpVersion": "7.1"
+                    "phpVersion": "7.3"
                 },
                 "name": "[parameters('webAppName')]",
                 "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]",

--- a/php/plain/webappOnLinux/armTemplates/linux-webapp-template.json
+++ b/php/plain/webappOnLinux/armTemplates/linux-webapp-template.json
@@ -17,7 +17,7 @@
         },
         "linuxFxVersion": {
             "type": "string",
-            "defaultValue": "php|7.0"
+            "defaultValue": "php|7.3"
         },
         "startupCommand": {
             "type": "string",

--- a/php/plain/webappWithTests/armTemplates/windows-webapp-template.json
+++ b/php/plain/webappWithTests/armTemplates/windows-webapp-template.json
@@ -60,7 +60,7 @@
                             "value": "6.9.1"
                         }
                     ],
-                    "phpVersion": "7.1"
+                    "phpVersion": "7.3"
                 },
                 "name": "[parameters('webAppName')]",
                 "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]",


### PR DESCRIPTION
1607007 : Upgrade PHP templates from 7.0 to 7.3 as 7.0 is not supported any more in web apps