### PR TITLE
Fix MVN Central repository not longer admit HTTP

### DIFF
--- a/java/spring/kubernetes/Application/pom.xml
+++ b/java/spring/kubernetes/Application/pom.xml
@@ -17,7 +17,7 @@
        <repository>
           <id>central</id>
           <name>Central</name>
-          <url>http://repo1.maven.org/maven2</url>
+          <url>https://repo1.maven.org/maven2</url>
        </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
Maven Central repository not longer admit HTTP
https://blog.sonatype.com/central-repository-moving-to-https