### PR TITLE
update CosmosDB to avoid conflicting on deployment

### DIFF
--- a/node/express/containerCosmosDBWithTests/ArmTemplates/container-webapp-template.json
+++ b/node/express/containerCosmosDBWithTests/ArmTemplates/container-webapp-template.json
@@ -128,14 +128,40 @@
             }
         },
         {
-            "apiVersion": "2015-04-08",
-            "kind": "MongoDB",
-            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "type": "Microsoft.DocumentDb/databaseAccounts",
+            "apiVersion": "2019-12-12",
             "name": "[parameters('databaseAccountId')]",
             "location": "[parameters('databaseAccountLocation')]",
+            "tags": {
+                "defaultExperience": "Azure Cosmos DB for MongoDB API",
+                "hidden-cosmos-mmspecial": "",
+                "CosmosAccountType": "Non-Production"
+            },
+            "kind": "MongoDB",
             "properties": {
+                "enableAnalyticalStorage": false,
                 "databaseAccountOfferType": "Standard",
-                "name": "[parameters('databaseAccountId')]"
+                "locations": [
+                    {
+                        "id": "[concat(parameters('databaseAccountId'), '-', parameters('databaseAccountLocation'))]",
+                        "failoverPriority": 0,
+                        "locationName": "[parameters('databaseAccountLocation')]"
+                    }
+                ],
+                "enableMultipleWriteLocations": false,
+                "isVirtualNetworkFilterEnabled": false,
+                "virtualNetworkRules": [],
+                "ipRangeFilter": "",
+                "dependsOn": [],
+                "capabilities": [
+                    {
+                        "name": "EnableMongo"
+                    },
+                    {
+                        "name": "DisableRateLimitingResponses"
+                    }
+                ],
+                "enableFreeTier": true
             }
         }
     ],


### PR DESCRIPTION
Following deployment error occurs when using original template

Deployment error
```
{
    "status": "Failed",
    "error": {
        "code": "ResourceDeploymentFailure",
        "message": "The resource operation completed with terminal provisioning state 'Failed'.",
        "details": [
            {
                "code": "ServiceUnavailable",
                "message": "Sorry, we are currently experiencing high demand in this region, and cannot fulfill your request at this time. We work continuously to bring more and more capacity online, and encourage you to try again shortly. Please do not hesitate to contact us via Azure support at any time or for any reason using this link http://aka.ms/azuresupport.\r\nActivityId: 8576becb-941d-4aff-979c-f41badfc026c, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0, Microsoft.Azure.Documents.Common/2.11.0"
            }
        ]
    }
}
```

Original ARM template
```
        {
            "apiVersion": "2015-04-08",
            "kind": "MongoDB",
            "type": "Microsoft.DocumentDB/databaseAccounts",
            "name": "[parameters('databaseAccountId')]",
            "location": "[parameters('databaseAccountLocation')]",
            "properties": {
                "databaseAccountOfferType": "Standard",
                "name": "[parameters('databaseAccountId')]"
            }
        }
```