### PR TITLE
Updating apiversion in deployment to yaml

### DIFF
--- a/dotnet/aspnetcore/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
+++ b/dotnet/aspnetcore/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
+++ b/dotnet/aspnetcore22/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/dotnet/aspnetcore31/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
+++ b/dotnet/aspnetcore31/kubernetes/Application/aspnet-core-dotnet-core/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/go/plain/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/go/plain/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/helmPackages/sampleChartWithOneService/sampleapp/templates/deployment.yaml
+++ b/helmPackages/sampleChartWithOneService/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/java/jsf/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/java/jsf/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/java/jsf/kubernetes/Application/charts/sampleapp/templates/redis-deployment.yaml
+++ b/java/jsf/kubernetes/Application/charts/sampleapp/templates/redis-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: {{ .Values.redis.service.name }}

--- a/java/spring/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/java/spring/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/express/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/express/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/express/kubernetes/Application/charts/sampleapp/templates/redis-deployment.yaml
+++ b/node/express/kubernetes/Application/charts/sampleapp/templates/redis-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: {{ .Values.redis.service.name }}

--- a/node/express/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/express/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/express/kubernetesCosmosDB/Application/charts/sampleapp/templates/redis-deployment.yaml
+++ b/node/express/kubernetesCosmosDB/Application/charts/sampleapp/templates/redis-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: {{ .Values.redis.service.name }}

--- a/node/plain/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/plain/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/plain/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/plain/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/sail.js/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/sail.js/kubernetes/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}

--- a/node/sail.js/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
+++ b/node/sail.js/kubernetesCosmosDB/Application/charts/sampleapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sampleapp.fullname" . }}


### PR DESCRIPTION
apiversion : apps/v1beta1 causes error (Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "apps/v1beta1") with higher kubernetes version, such as 1.17
Feedback ticket : https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/1751106