### PR TITLE
fix npm start script

### DIFF
--- a/node/express/containerCosmosDBWithTests/Application/package.json
+++ b/node/express/containerCosmosDBWithTests/Application/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "set NODE_ENV=production&& node --no-deprecation app"
+    "start": "set NODE_ENV=production && node --no-deprecation app"
   },
   "description": "nodejs-webapp-express",
   "author": {


### PR DESCRIPTION
npm start was failing due to missing space in start command